### PR TITLE
More compact selectors in development mode

### DIFF
--- a/lib/applyStyles.js
+++ b/lib/applyStyles.js
@@ -9,10 +9,16 @@ var COMPLEX_OVERRIDES = CSSProperty.shorthandPropertyExpansions;
 function applyClassName(props, className, order, maxOverridesLength) {
   if (!props.className) {
     props.className = '';
+  } else {
+    props.className += ' ';
   }
   var length = !maxOverridesLength || (order + 1) <= maxOverridesLength ? order + 1 : maxOverridesLength;
-  for (var j = 0; j < length; j++) {
-    props.className += ' ' + className + (j === 0 ? '' : j);
+  props.className += className;
+  if ("production" !== process.env.NODE_ENV) {
+      className = className.replace(/^.*_([^_]+)$/, '$1');
+  }
+  for (var j = 1; j < length; j++) {
+    props.className += ' ' + className + j;
   }
 
   return order + 1;

--- a/lib/stylesToCSS.js
+++ b/lib/stylesToCSS.js
@@ -72,9 +72,10 @@ function replicateSelector(s, max) {
   var maxLength = max || 10;
   var replicatedSelector = [];
   for (var i = 0; i < maxLength; i++) {
-    var newSelector = '';
-    for (var j = 0, l2 = i + 1; j < l2; j++) {
-      newSelector += s + (j !==0 ? j : '');
+    var newSelector = '.' + s;
+    var q = s.replace(/^.*_([^_]+)$/, '$1');
+    for (var j = 1, l2 = i + 1; j < l2; j++) {
+      newSelector += '.' + q + j;
     }
     replicatedSelector[i] = newSelector;
   }
@@ -90,7 +91,7 @@ function buildStyle(result, style, selector, maxLength) {
   }
   if (!selector) {
     result.classNames[style.className] = counter++;
-    selector = replicateSelector('.' + style.className, maxLength);
+    selector = replicateSelector(style.className, maxLength);
   }
   if(!selector.indexOf('.@media ')) {
     buildMediaQuery(result, style.style, selector.substr(1));


### PR DESCRIPTION
In development mode, selectors take the form styleName_xx where xx is a unique ID. For specificity overrides, a selector might read `.styleName_xx, styleName_xx.styleName_xx1, styleName_xx.styleName_xx1.styleName_xx2`.  This seems overly verbose. This change drops the styleName prefix from the additional class names used to override specificity, so that the selector instead reads `.styleName_xx, .styleName_xx.xx1, .styleName_xx.xx1.xx2`.