### PR TITLE
Remove reactify config

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,5 @@
   "jest": {
     "rootDir": "",
     "scriptPreprocessor": "jest/preprocessor.js"
-  },
-  "browserify" : {
-    "transform" : [
-	  ["reactify", {"es6": true}]
-    ]
   }
 }


### PR DESCRIPTION
Remove reactify config. It doesn't have transpile during browserify because it's already removed ES6 by https://github.com/js-next/react-style/issues/91 