### PR TITLE
handle multiple stylesheets with media queries in production

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,9 @@ var keys                            = Object.keys;
 
 var registeredMediaQueries          = [];
 var styles                          = [];
+var mediaQueries                    = {};
+
+var isProduction                    = process.env.NODE_ENV === 'production';
 
 function createStyle(props, className, uniqueKey) {
   styles.push({
@@ -42,7 +45,7 @@ function createStyleSheet(stylesheet, useClassName) {
       var style = stylesheet[styleName];
       var origUniqueKey = generateUniqueCSSClassName();
       var uniqueKey = origUniqueKey;
-      if ("production" !== process.env.NODE_ENV) {
+      if (!isProduction) {
         uniqueKey = styleName + '_' + uniqueKey;
       }
 
@@ -57,6 +60,22 @@ function createStyleSheet(stylesheet, useClassName) {
             newStyle[uniqueKey2] = mqStyle;
           }
         }
+
+        if (isProduction) {
+          if (!mediaQueries[styleName]) {
+            mediaQueries[styleName] = {};
+          }
+
+          keys(newStyle).reduce(function ( acc, key ) {
+            if (!acc[key]) {
+              acc[key] = newStyle[key];
+            }
+            return acc;
+          }, mediaQueries[styleName]);
+
+          continue;
+        }
+
         style = newStyle;
       }
       results[styleName] = createStyle(style, isMediaQuery ? styleName : uniqueKey, origUniqueKey);
@@ -68,7 +87,15 @@ function createStyleSheet(stylesheet, useClassName) {
 
 var StyleSheet = {
   compile: function(maxLength) {
-    return stylesToCSS(styles, maxLength || 10);
+    var mq = keys(mediaQueries).map(function(query){
+      return {
+        style: mediaQueries[query],
+        className: query,
+        uniqueKey: ''
+      }
+    });
+
+    return stylesToCSS(styles.concat(mq), maxLength || 10);
   },
   create: createStyleSheet
 };


### PR DESCRIPTION
When building a css file using webpack in production, in a project with multiple stylesheets which contains media queries with the same query, only of media query style group is applied to the final style sheet.

This change fixes this, and combines all media queries at the end of the stylesheet, sharing the actual media queries.