### PR TITLE
Add npmignore to ignore examples/ directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+examples/


### PR DESCRIPTION
The examples directory causes a very large number of packages to be installed. By adding it to npmignore, installation time is substantially decreased. This reduces the build time for many projects.
