### PR TITLE
Add `styles` property name clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Style React components:
 
     }
 
-By default styles are applied to the DOM as inline styles.
+Notice that the property is `styles`, not `style`. By default styles are applied to the DOM as inline styles.
 
 ## Extracting styles into CSS at build time
 


### PR DESCRIPTION
To avoid people doing something like `<div style={[styles.foo]}></div>` initially.