### PR TITLE
compatibility with react@0.14.0-beta3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 var assign                          = require("react/lib/Object.assign");
 var ReactElementExtended            = require('./ReactElementExtended');
 var ReactCompositeComponentExtended = require('./ReactCompositeComponentExtended.js');
-var ExecutionEnvironment            = require('react/lib/ExecutionEnvironment');
 
 var applyMediaQueries               = require('./applyMediaQueries');
 var generateUniqueCSSClassName      = require('./generateUniqueCSSClassName');

--- a/lib/stylesToCSS.js
+++ b/lib/stylesToCSS.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var isUnitlessNumber = require('react/lib/CSSProperty').isUnitlessNumber;
-var hyphenateStyleName = require('react/lib/hyphenateStyleName');
+var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
 var isArray = Array.isArray;
 var keys = Object.keys;
 var unsupportedPseudoClasses = require('./unsupportedPseudoClasses');

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": ">=0.12.0 || 0.13.0-rc1 || 0.13.0-rc2 || >=0.13.0"
   },
   "devDependencies": {
+    "fbjs": ">=0.1.0-alpha.12",
     "jest-cli": "^0.4.0",
     "jshint": "^2.6.3",
     "jsx-loader": "^0.12.2",


### PR DESCRIPTION
I don't expect this to be merged at all, but it should help those who are using the latest React beta (probably for better context management) but also want to use react-style.

Why was `ExecutionEnvironment` required at all? It's not used in `index.js`?

Cheers