### PR TITLE
Working with React 0.15

### DIFF
--- a/lib/ReactCompositeComponentExtended.js
+++ b/lib/ReactCompositeComponentExtended.js
@@ -15,8 +15,8 @@ if (ReactCompositeComponent.Mixin) {
   originalMountComponent = ReactComponent.Mixin.mountComponent;
 }
 
-mountExtensionPoint.Mixin.mountComponent = function(rootID, transaction, context) {
-  var call = originalMountComponent.call(this, rootID, transaction, context);
+mountExtensionPoint.Mixin.mountComponent = function(transaction, hostParent, hostContainerInfo, context) {
+  var call = originalMountComponent.call(this, transaction, hostParent, hostContainerInfo, context);
   var instance = !this._instance ? this : this._instance;
   var props = instance.props;
   if (props && props.__cachedStyles) {

--- a/lib/ReactElementExtended.js
+++ b/lib/ReactElementExtended.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var ReactElement  = require('react/lib/ReactElement');
-var assign        = require("react/lib/Object.assign");
+var assign        = require("object-assign");
 var applyStyles   = require('./applyStyles');
 var isArray       = Array.isArray;
 
@@ -10,8 +10,7 @@ var helperObj = {};
 function buildProps(props) {
   var builtProps = {
     className: props.className || null,
-    style: props.style ? assign({}, props.style) : null,
-    styles: undefined
+    style: props.style ? assign({}, props.style) : null
   };
   applyStyles(builtProps, props.styles, 0, null, helperObj.maxOverridesLength);
   return builtProps;
@@ -27,6 +26,11 @@ ReactElement.createElement = function(type, props) {
     props.__cachedStyles = isArray(props.styles) ? props.styles : [props.styles];
     assign(props, buildProps(props));
   }
+
+  //remove "styles" and "__cachedStyles" unknown-props @https://facebook.github.io/react/warnings/unknown-prop.html
+  props && props.styles && delete props.styles;
+  props && props.__cachedStyles && delete props.__cachedStyles;
+
   return originalCreateElement.apply(this, [type, props].concat(Array.prototype.slice.call(args, 2)));
 };
 

--- a/lib/__tests__/applyMediaQueries-test.js
+++ b/lib/__tests__/applyMediaQueries-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 jest.dontMock('../applyMediaQueries');
-jest.dontMock('react/lib/Object.assign');
+jest.dontMock("object-assign");
 
 describe('applyMediaQueries', function() {
 

--- a/lib/applyMediaQueries.js
+++ b/lib/applyMediaQueries.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assign                 = require("react/lib/Object.assign");
+var assign                 = require("object-assign");
 var recalcMediaQueryStyles = require('./recalcMediaQueryStyles');
 
 var matchMedia = null;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var assign                          = require("react/lib/Object.assign");
+var assign                          = require("object-assign");
 var ReactElementExtended            = require('./ReactElementExtended');
 var ReactCompositeComponentExtended = require('./ReactCompositeComponentExtended.js');
-var ExecutionEnvironment            = require('react/lib/ExecutionEnvironment');
 
 var applyMediaQueries               = require('./applyMediaQueries');
 var generateUniqueCSSClassName      = require('./generateUniqueCSSClassName');

--- a/lib/recalcMediaQueryStyles.js
+++ b/lib/recalcMediaQueryStyles.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var assign                          = require("react/lib/Object.assign");
+var assign                          = require("object-assign");
 var applyStyles                     = require('./applyStyles');
 var enqueueForceUpdate;
 

--- a/lib/stylesToCSS.js
+++ b/lib/stylesToCSS.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var isUnitlessNumber = require('react/lib/CSSProperty').isUnitlessNumber;
-var hyphenateStyleName = require('react/lib/hyphenateStyleName');
+var hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
 var isArray = Array.isArray;
 var keys = Object.keys;
 var unsupportedPseudoClasses = require('./unsupportedPseudoClasses');

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-style",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Maintainable styling for React.js components",
   "main": "lib/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.12.0 || 0.13.0-rc1 || 0.13.0-rc2 || >=0.13.0 || >=0.14.0",
+    "react": ">=0.12.0 || 0.13.0-rc1 || 0.13.0-rc2 || >=0.13.0 || >=0.14.0 || >=0.15.0",
     "fbjs": "^0.4.0",
     "object-assign": "^4.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "lib/index.js",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.12.0 || 0.13.0-rc1 || 0.13.0-rc2 || >=0.13.0"
+    "react": ">=0.12.0 || 0.13.0-rc1 || 0.13.0-rc2 || >=0.13.0 || >=0.14.0",
+    "fbjs": "^0.4.0",
+    "object-assign": "^4.1.0"
   },
   "devDependencies": {
     "jest-cli": "^0.4.0",


### PR DESCRIPTION
It is base on the version which was fixed by @tylerwgoza.

React 0.15 has removed 'react/lib/Object.assign'. So I change a lots files to get assign from 'object-assign' and it is added into peerDependency.

API MountComponent's params are also updated. 
ReactElementExtended.js remove 'styles' and '__cacheStyles' because of unknown-props waring.
